### PR TITLE
read aQGC weights

### DIFF
--- a/classes/ClassesLinkDef.h
+++ b/classes/ClassesLinkDef.h
@@ -31,6 +31,7 @@
 #pragma link C++ class Event+;
 #pragma link C++ class LHCOEvent+;
 #pragma link C++ class LHEFEvent+;
+#pragma link C++ class LHEFrwgt+;
 #pragma link C++ class HepMCEvent+;
 #pragma link C++ class GenParticle+;
 #pragma link C++ class LHEParticle+;

--- a/classes/DelphesClasses.h
+++ b/classes/DelphesClasses.h
@@ -51,6 +51,18 @@ class LHCOEvent: public Event{
 
 //---------------------------------------------------------------------------
 
+class LHEFrwgt : public TObject {
+  
+ public:
+  
+  std::vector<int> opNum;
+  std::vector<double> opVal;
+  ClassDef(LHEFrwgt, 1)
+
+};
+
+//---------------------------------------------------------------------------
+
 class LHEFEvent: public Event {
   
   public:
@@ -60,8 +72,8 @@ class LHEFEvent: public Event {
   Float_t ScalePDF; // scale in GeV used in the calculation of the PDFs in the event | hepup.SCALUP
   Float_t AlphaQED; // value of the QED coupling used in the event | hepup.AQEDUP
   Float_t AlphaQCD; // value of the QCD coupling used in the event | hepup.AQCDUP
-
-  ClassDef(LHEFEvent, 2)
+  std::vector<Double_t> lheWeights;
+  ClassDef(LHEFEvent, 3)
 };
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Add some functionalities for aQGC studies:

 -- Create another tree called Weights in the output file.
 -- The Weights tree is only filled if the aQGC package is found in the header.
 -- The first entry has a list of all the value of the operators used in the main generation (therefore, the phase space sampling). There is a small class "container" LHEFrwgt to save the operator number and the value used.
 -- The following entries have the weights used for each reweights (but only the operators that changed).
 -- Added the member LHEFEvent.lheWeights to the LHEFEvent class inside the Delphes trees to save the recalculated weight. This is pretty generic, it will save any kind of weight, but the interpretation is only possible if the Weights tree is also filled (meaning, the block in the header is found).
